### PR TITLE
Fix: Migrate Bank Soal Import to Excel & Enhance Auto-Heal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,10 +10,12 @@
         "@elysiajs/static": "^1.4.10",
         "@types/nodemailer": "^8.0.0",
         "bcryptjs": "^3.0.3",
+        "bootstrap-icons": "^1.13.1",
         "drizzle-orm": "^0.45.2",
         "elysia": "^1.4.28",
         "mysql2": "^3.22.3",
         "nodemailer": "^8.0.7",
+        "xlsx": "^0.18.5",
       },
       "devDependencies": {
         "@types/bcryptjs": "^3.0.0",
@@ -110,6 +112,8 @@
 
     "@types/nodemailer": ["@types/nodemailer@8.0.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA=="],
 
+    "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
+
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
@@ -118,15 +122,23 @@
 
     "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
 
+    "bootstrap-icons": ["bootstrap-icons@1.13.1", "", {}, "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw=="],
+
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
+    "codepage": ["codepage@1.15.0", "", {}, "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="],
+
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -151,6 +163,8 @@
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "file-type": ["file-type@22.0.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA=="],
+
+    "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -196,6 +210,8 @@
 
     "sql-escaper": ["sql-escaper@1.3.3", "", {}, "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw=="],
 
+    "ssf": ["ssf@0.11.2", "", { "dependencies": { "frac": "~1.1.2" } }, "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g=="],
+
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -214,7 +230,13 @@
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "wmf": ["wmf@1.0.2", "", {}, "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="],
+
+    "word": ["word@0.3.0", "", {}, "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="],
+
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "xlsx": ["xlsx@0.18.5", "", { "dependencies": { "adler-32": "~1.3.0", "cfb": "~1.2.1", "codepage": "~1.15.0", "crc-32": "~1.2.1", "ssf": "~0.11.2", "wmf": "~1.0.1", "word": "~0.3.0" }, "bin": { "xlsx": "bin/xlsx.njs" } }, "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "@elysiajs/static": "^1.4.10",
     "@types/nodemailer": "^8.0.0",
     "bcryptjs": "^3.0.3",
+    "bootstrap-icons": "^1.13.1",
     "drizzle-orm": "^0.45.2",
     "elysia": "^1.4.28",
     "mysql2": "^3.22.3",
-    "nodemailer": "^8.0.7"
+    "nodemailer": "^8.0.7",
+    "xlsx": "^0.18.5"
   }
 }

--- a/src/routes/bank_soal.ts
+++ b/src/routes/bank_soal.ts
@@ -5,47 +5,67 @@ import {
   questionBank, gameFillTheBlank,
   projects
 } from "../db/schema";
-import { eq, sql } from "drizzle-orm";
+import { eq, sql, inArray } from "drizzle-orm";
 import { jwt } from "@elysiajs/jwt";
+import * as XLSX from "xlsx";
 
 // ── Native CSV parser (handles quoted fields, CRLF/LF, UTF-8 BOM, semicolon/comma delimiter) ──
 function parseCSV(text: string): Record<string, string>[] {
-  // Strip UTF-8 BOM jika ada
   const clean = text.startsWith('\uFEFF') ? text.slice(1) : text;
-  // Normalise line endings
-  const lines = clean.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
-  if (lines.length < 2) return [];
-
-  // Auto-detect delimiter: Excel Indonesia menggunakan ';', internasional ','
-  const headerLine = lines[0]!;
-  const commaCount = (headerLine.match(/,/g) || []).length;
-  const semicolonCount = (headerLine.match(/;/g) || []).length;
+  
+  let firstLineEnd = clean.indexOf('\n');
+  if (firstLineEnd === -1) firstLineEnd = clean.length;
+  const headerLineRaw = clean.slice(0, firstLineEnd);
+  
+  const commaCount = (headerLineRaw.match(/,/g) || []).length;
+  const semicolonCount = (headerLineRaw.match(/;/g) || []).length;
   const delim = semicolonCount > commaCount ? ';' : ',';
 
-  const parseRow = (line: string): string[] => {
-    const fields: string[] = [];
-    let cur = '', inQ = false;
-    for (let i = 0; i < line.length; i++) {
-      const ch = line[i] ?? '';
-      if (ch === '"') {
-        if (inQ && line[i + 1] === '"') { cur += '"'; i++; }
-        else inQ = !inQ;
-      } else if (ch === delim && !inQ) {
-        fields.push(cur.trim()); cur = '';
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let cur = '';
+  let inQ = false;
+  
+  for (let i = 0; i < clean.length; i++) {
+    const ch = clean[i];
+    if (ch === '"') {
+      if (inQ && clean[i + 1] === '"') { 
+        cur += '"'; 
+        i++; 
       } else {
-        cur += ch;
+        inQ = !inQ;
+      }
+    } else if (ch === delim && !inQ) {
+      currentRow.push(cur.trim());
+      cur = '';
+    } else if ((ch === '\n' || (ch === '\r' && clean[i+1] === '\n')) && !inQ) {
+      if (ch === '\r') i++;
+      currentRow.push(cur.trim());
+      rows.push(currentRow);
+      currentRow = [];
+      cur = '';
+    } else {
+      if (ch === '\r' && !inQ) {
+         // abaikan \r di luar quote
+      } else {
+         cur += ch;
       }
     }
-    fields.push(cur.trim());
-    return fields;
-  };
+  }
+  
+  if (cur !== '' || currentRow.length > 0) {
+    currentRow.push(cur.trim());
+    rows.push(currentRow);
+  }
 
-  const headers = parseRow(headerLine);
+  if (rows.length < 2) return [];
+
+  const headers = rows[0]!;
   const results: Record<string, string>[] = [];
-  for (let i = 1; i < lines.length; i++) {
-    const line = (lines[i] ?? '').trim();
-    if (!line) continue;
-    const values = parseRow(line);
+  for (let i = 1; i < rows.length; i++) {
+    const values = rows[i]!;
+    if (values.length === 1 && !values[0]) continue;
+    
     const row: Record<string, string> = {};
     headers.forEach((h, idx) => { row[h.trim()] = values[idx] ?? ''; });
     results.push(row);
@@ -53,6 +73,16 @@ function parseCSV(text: string): Record<string, string>[] {
   return results;
 }
 
+
+
+// Helper: normalisasi nilai difficulty dari berbagai format ke MUDAH/SEDANG/SULIT
+function normalizeDifficulty(val: string): string | null {
+  const v = String(val || '').trim().toUpperCase();
+  if (['MUDAH', 'EASY', 'GAMPANG', 'RENDAH', 'LOW', '1', 'MUDAH'].includes(v)) return 'MUDAH';
+  if (['SEDANG', 'MEDIUM', 'NORMAL', 'MENENGAH', 'MID', 'MIDDLE', '2'].includes(v)) return 'SEDANG';
+  if (['SULIT', 'SUSAH', 'HARD', 'DIFFICULT', 'TINGGI', 'HIGH', '3'].includes(v)) return 'SULIT';
+  return null;
+}
 
 // Helper: hanya KETUA_TIM dan PEMBUAT_GAME yang boleh akses Bank Soal
 function guardBankSoal(user: any) {
@@ -112,6 +142,16 @@ export const bankSoalRoutes = new Elysia({ prefix: "/api/bank-soal" })
     return { success: true };
   })
 
+  .post("/quiz/bulk-delete", async ({ body, user }) => {
+    const guard = guardBankSoal(user);
+    if (guard) return guard;
+    const { ids } = body as { ids: number[] };
+    if (ids && ids.length > 0) {
+      await db.delete(bankSoalQuiz).where(inArray(bankSoalQuiz.id, ids));
+    }
+    return { success: true };
+  })
+
   .delete("/quiz/:id", async ({ params, user }) => {
     const guard = guardBankSoal(user);
     if (guard) return guard;
@@ -154,6 +194,16 @@ export const bankSoalRoutes = new Elysia({ prefix: "/api/bank-soal" })
     return { success: true };
   })
 
+  .post("/ftb/bulk-delete", async ({ body, user }) => {
+    const guard = guardBankSoal(user);
+    if (guard) return guard;
+    const { ids } = body as { ids: number[] };
+    if (ids && ids.length > 0) {
+      await db.delete(bankSoalFtb).where(inArray(bankSoalFtb.id, ids));
+    }
+    return { success: true };
+  })
+
   .delete("/ftb/:id", async ({ params, user }) => {
     const guard = guardBankSoal(user);
     if (guard) return guard;
@@ -193,6 +243,16 @@ export const bankSoalRoutes = new Elysia({ prefix: "/api/bank-soal" })
     return { success: true };
   })
 
+  .post("/tts/bulk-delete", async ({ body, user }) => {
+    const guard = guardBankSoal(user);
+    if (guard) return guard;
+    const { ids } = body as { ids: number[] };
+    if (ids && ids.length > 0) {
+      await db.delete(bankSoalTts).where(inArray(bankSoalTts.id, ids));
+    }
+    return { success: true };
+  })
+
   .delete("/tts/:id", async ({ params, user }) => {
     const guard = guardBankSoal(user);
     if (guard) return guard;
@@ -201,7 +261,49 @@ export const bankSoalRoutes = new Elysia({ prefix: "/api/bank-soal" })
   })
 
   // ============================================================
-  // IMPORT CSV — Quiz / FTB / TTS
+  // TEMPLATE EXCEL
+  // ============================================================
+  .get("/template/:type", async ({ params }) => {
+    const type = params.type as "quiz" | "ftb" | "tts";
+    const workbook = XLSX.utils.book_new();
+    let worksheet;
+    let filename = "Template_Bank_Soal.xlsx";
+
+    if (type === "quiz") {
+      filename = "Template_Bank_Soal_Quiz.xlsx";
+      worksheet = XLSX.utils.json_to_sheet([
+        { question: "Apa ibukota Indonesia?", optionA: "Jakarta", optionB: "Bandung", optionC: "Surabaya", optionD: "Medan", correctAnswer: "A", difficulty: "MUDAH", explanation: "Jakarta adalah ibukota negara RI." },
+        { question: "Pusat tata surya adalah...", optionA: "Bumi", optionB: "Bulan", optionC: "Matahari", optionD: "Mars", correctAnswer: "C", difficulty: "SEDANG", explanation: "Matahari adalah pusat tata surya." }
+      ]);
+    } else if (type === "ftb") {
+      filename = "Template_Bank_Soal_FTB.xlsx";
+      worksheet = XLSX.utils.json_to_sheet([
+        { fullText: "Ibukota Indonesia adalah [Jakarta] yang terletak di Pulau [Jawa].", difficulty: "MUDAH", word1: "Jakarta", explanation1: "Kota metropolitan terbesar", word2: "Jawa", explanation2: "Pulau terpadat di Indonesia", word3: "", explanation3: "" },
+        { fullText: "Proses fotosintesis menghasilkan [oksigen] dan [glukosa].", difficulty: "SEDANG", word1: "oksigen", explanation1: "Gas pernafasan", word2: "glukosa", explanation2: "Sumber energi", word3: "", explanation3: "" }
+      ]);
+    } else if (type === "tts") {
+      filename = "Template_Bank_Soal_TTS.xlsx";
+      worksheet = XLSX.utils.json_to_sheet([
+        { clue: "Ibukota Indonesia", answer: "JAKARTA", difficulty: "MUDAH", explanation: "Terletak di pulau Jawa" },
+        { clue: "Pusat tata surya", answer: "MATAHARI", difficulty: "SEDANG", explanation: "Bintang terdekat dengan bumi" }
+      ]);
+    } else {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    XLSX.utils.book_append_sheet(workbook, worksheet, "Template");
+    const buffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
+    
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition": `attachment; filename="${filename}"`
+      }
+    });
+  })
+
+  // ============================================================
+  // IMPORT EXCEL — Quiz / FTB / TTS
   // ============================================================
   .post("/import/:type", async ({ params, body, user }) => {
     const guard = guardBankSoal(user);
@@ -212,28 +314,42 @@ export const bankSoalRoutes = new Elysia({ prefix: "/api/bank-soal" })
     const file = formData?.file;
 
     if (!file) {
-      return new Response(JSON.stringify({ error: "File CSV tidak ditemukan. Pastikan Anda memilih file .csv yang valid." }), { status: 400 });
+      return new Response(JSON.stringify({ error: "File Excel tidak ditemukan. Pastikan Anda memilih file .xlsx yang valid." }), { status: 400 });
     }
 
     // Validasi ekstensi file
     const fileName: string = (file as any).name || "";
-    if (!fileName.toLowerCase().endsWith(".csv")) {
-      return new Response(JSON.stringify({ error: `File harus berformat .csv. File yang diterima: ${fileName}` }), { status: 400 });
+    if (!fileName.toLowerCase().endsWith(".xlsx") && !fileName.toLowerCase().endsWith(".xls") && !fileName.toLowerCase().endsWith(".csv")) {
+      return new Response(JSON.stringify({ error: `File harus berformat Excel (.xlsx/.xls) atau .csv. File yang diterima: ${fileName}` }), { status: 400 });
     }
 
     try {
-      // Baca file sebagai teks (efisien untuk ribuan baris)
-      let csvText: string;
+      let rows: Record<string, any>[] = [];
       if (typeof file === "object" && file instanceof Blob) {
-        csvText = await file.text();
+        const arrayBuffer = await file.arrayBuffer();
+        const workbook = XLSX.read(arrayBuffer, { type: 'array', cellDates: true });
+        
+        // Baca semua sheet dan gabungkan
+        for (const sheetName of workbook.SheetNames) {
+          const worksheet = workbook.Sheets[sheetName];
+          // defval:'': sel kosong tetap terbaca sebagai string kosong (bukan undefined)
+          // raw:false: angka/tanggal dikonversi ke string
+          // blankrows:false: skip baris yang benar-benar kosong
+          const sheetRows = XLSX.utils.sheet_to_json<Record<string, any>>(worksheet, {
+            defval: '',
+            raw: false,
+            blankrows: false
+          });
+          console.log(`[Import] Sheet "${sheetName}": ${sheetRows.length} baris. Header:`, sheetRows[0] ? Object.keys(sheetRows[0]).join(', ') : 'kosong');
+          rows = rows.concat(sheetRows);
+        }
+        console.log(`[Import] Total baris dari semua sheet: ${rows.length}`);
       } else {
         return new Response(JSON.stringify({ error: "Format file tidak valid" }), { status: 400 });
       }
 
-      const rows = parseCSV(csvText);
-
       if (!rows.length) {
-        return new Response(JSON.stringify({ error: "File CSV kosong atau header tidak sesuai template. Pastikan baris pertama adalah header kolom." }), { status: 400 });
+        return new Response(JSON.stringify({ error: "File Excel kosong atau header tidak sesuai template. Pastikan baris pertama adalah header kolom." }), { status: 400 });
       }
 
       let imported = 0;
@@ -241,29 +357,46 @@ export const bankSoalRoutes = new Elysia({ prefix: "/api/bank-soal" })
       const BATCH_SIZE = 500; // Batch insert untuk performa ribuan baris
 
       if (type === "quiz") {
+        const existingData = await db.select({ question: bankSoalQuiz.question }).from(bankSoalQuiz);
+        const existingSet = new Set(existingData.map(d => (d.question || "").trim().toLowerCase()));
         const batch: any[] = [];
         for (let i = 0; i < rows.length; i++) {
           const r = rows[i];
           if (!r) continue;
-          if (!r.question || !r.optionA || !r.optionB || !r.optionC || !r.optionD || !r.correctAnswer || !r.difficulty) {
-            errors.push(`Baris ${i + 2}: Field wajib kosong (question/optionA-D/correctAnswer/difficulty), dilewati`);
+          const q = r.question || r.pertanyaan || r.soal || r.Question || r.Pertanyaan || '';
+          const diffRaw = r.difficulty || r.tingkat_kesulitan || r.kesulitan || r.Difficulty || '';
+          const optA = r.optionA || r.pilihanA || r.pilihan_a || r.OptionA || '';
+          const optB = r.optionB || r.pilihanB || r.pilihan_b || r.OptionB || '';
+          const optC = r.optionC || r.pilihanC || r.pilihan_c || r.OptionC || '';
+          const optD = r.optionD || r.pilihanD || r.pilihan_d || r.OptionD || '';
+          const caRaw = r.correctAnswer || r.jawaban_benar || r.kunci_jawaban || r.kunci || r.jawaban || '';
+          const expl = r.explanation || r.penjelasan || r.pembahasan || '';
+
+          if (!q || !optA || !optB || !optC || !optD || !caRaw || !diffRaw) {
+            errors.push(`Baris ${i + 2}: Field wajib kosong, dilewati`);
             continue;
           }
-          const diff = String(r.difficulty).trim().toUpperCase();
-          if (!["MUDAH", "SEDANG", "SULIT"].includes(diff)) {
-            errors.push(`Baris ${i + 2}: difficulty '${r.difficulty}' tidak valid. Gunakan: MUDAH, SEDANG, atau SULIT`);
+          const qText = q.trim().toLowerCase();
+          if (existingSet.has(qText)) {
+            errors.push(`Baris ${i + 2}: Pertanyaan ganda, dilewati`);
             continue;
           }
-          const ca = String(r.correctAnswer).trim().toUpperCase();
+          existingSet.add(qText);
+          const diff = normalizeDifficulty(diffRaw);
+          if (!diff) {
+            errors.push(`Baris ${i + 2}: difficulty '${diffRaw}' tidak valid`);
+            continue;
+          }
+          const ca = String(caRaw).trim().toUpperCase();
           if (!["A", "B", "C", "D"].includes(ca)) {
-            errors.push(`Baris ${i + 2}: correctAnswer '${r.correctAnswer}' tidak valid. Gunakan: A, B, C, atau D`);
+            errors.push(`Baris ${i + 2}: jawaban benar '${caRaw}' tidak valid`);
             continue;
           }
           batch.push({
-            question: r.question, optionA: r.optionA, optionB: r.optionB,
-            optionC: r.optionC, optionD: r.optionD,
+            question: q, optionA: optA, optionB: optB,
+            optionC: optC, optionD: optD,
             correctAnswer: ca as any, difficulty: diff as any,
-            explanation: r.explanation || "", createdBy: user.id
+            explanation: expl, createdBy: user.id
           });
           // Flush batch setiap BATCH_SIZE baris
           if (batch.length >= BATCH_SIZE) {
@@ -279,31 +412,50 @@ export const bankSoalRoutes = new Elysia({ prefix: "/api/bank-soal" })
         }
 
       } else if (type === "ftb") {
+        const existingData = await db.select({ fullText: bankSoalFtb.fullText }).from(bankSoalFtb);
+        const existingSet = new Set(existingData.map(d => (d.fullText || "").trim().toLowerCase()));
         const batch: any[] = [];
         for (let i = 0; i < rows.length; i++) {
           const r = rows[i];
           if (!r) continue;
-          if (!r.fullText || !r.difficulty) {
-            errors.push(`Baris ${i + 2}: fullText atau difficulty kosong, dilewati`);
+          const fullText = String(r.fullText || r.fulltext || r.teksutuh || r['full text'] || r['teks utuh'] || r.FullText || r.pertanyaan || r.soal || r.Question || r.Pertanyaan || '').trim();
+          let diffRaw = String(r.difficulty || r.tingkat_kesulitan || r.kesulitan || r.Difficulty || r.Tingkat_Kesulitan || '').trim();
+          
+          if (!fullText) {
+            errors.push(`Baris ${i + 2}: Kolom fullText kosong. Kolom tersedia: ${Object.keys(r).join(', ')}`);
             continue;
           }
-          const diff = String(r.difficulty).trim().toUpperCase();
-          if (!["MUDAH", "SEDANG", "SULIT"].includes(diff)) {
-            errors.push(`Baris ${i + 2}: difficulty '${r.difficulty}' tidak valid, dilewati`);
+          const qText = fullText.toLowerCase();
+          if (existingSet.has(qText)) {
+            errors.push(`Baris ${i + 2}: Pertanyaan ganda, dilewati`);
             continue;
           }
-          // Baca hingga 5 pasang word/explanation
-          const answers: { word: string; explanation: string }[] = [];
+          existingSet.add(qText);
+          
+          // Auto-heal difficulty
+          if (!diffRaw) diffRaw = 'MUDAH';
+          const diff = normalizeDifficulty(diffRaw) || 'MUDAH';
+
+          // Baca hingga 5 pasang word/explanation — coba juga nama kolom alternatif
+          let answers: { word: string; explanation: string }[] = [];
           for (let k = 1; k <= 5; k++) {
-            const w = r[`word${k}`];
-            if (w && w.trim()) answers.push({ word: w.trim(), explanation: (r[`explanation${k}`] || "").trim() });
+            const w = String(r[`word${k}`] || r[`kata${k}`] || r[`answer${k}`] || r[`jawaban${k}`] || r[`Word${k}`] || r[`kata rumpang ${k}`] || r[`word ${k}`] || r[`Kata${k}`] || '').trim();
+            const expl = String(r[`explanation${k}`] || r[`penjelasan${k}`] || r[`keterangan${k}`] || r[`Explanation${k}`] || r[`penjelasan ${k}`] || r[`explanation ${k}`] || '').trim();
+            if (w) answers.push({ word: w, explanation: expl });
           }
+          
+          // Auto-heal: jika tidak ada word di kolom, coba ekstrak dari kurung siku [...] di teks utuh
           if (!answers.length) {
-            errors.push(`Baris ${i + 2}: Tidak ada kata rumpang (kolom word1 hingga word5 kosong), dilewati`);
+            const matches = [...fullText.matchAll(/\[(.*?)\]/g)];
+            answers = matches.map(m => ({ word: m[1].trim(), explanation: '' })).filter(a => a.word !== '');
+          }
+
+          if (!answers.length) {
+            errors.push(`Baris ${i + 2}: Tidak ada kata rumpang. Isi kolom word1 atau tandai kata dengan [...] di teks.`);
             continue;
           }
           batch.push({
-            fullText: r.fullText, answers: JSON.stringify(answers),
+            fullText: fullText, answers: JSON.stringify(answers),
             difficulty: diff as any, createdBy: user.id
           });
           if (batch.length >= BATCH_SIZE) {
@@ -318,22 +470,35 @@ export const bankSoalRoutes = new Elysia({ prefix: "/api/bank-soal" })
         }
 
       } else if (type === "tts") {
+        const existingData = await db.select({ clue: bankSoalTts.clue }).from(bankSoalTts);
+        const existingSet = new Set(existingData.map(d => (d.clue || "").trim().toLowerCase()));
         const batch: any[] = [];
         for (let i = 0; i < rows.length; i++) {
           const r = rows[i];
           if (!r) continue;
-          if (!r.clue || !r.answer || !r.difficulty) {
+          const clueRaw = r.clue || r.petunjuk || r.pertanyaan || r.Clue || '';
+          const ansRaw = r.answer || r.jawaban || r.Answer || '';
+          const diffRaw = r.difficulty || r.tingkat_kesulitan || r.kesulitan || r.Difficulty || '';
+          const expl = r.explanation || r.penjelasan || r.pembahasan || '';
+
+          if (!clueRaw || !ansRaw || !diffRaw) {
             errors.push(`Baris ${i + 2}: clue/answer/difficulty kosong, dilewati`);
             continue;
           }
-          const diff = String(r.difficulty).trim().toUpperCase();
-          if (!["MUDAH", "SEDANG", "SULIT"].includes(diff)) {
-            errors.push(`Baris ${i + 2}: difficulty '${r.difficulty}' tidak valid, dilewati`);
+          const qText = clueRaw.trim().toLowerCase();
+          if (existingSet.has(qText)) {
+            errors.push(`Baris ${i + 2}: Clue ganda, dilewati`);
+            continue;
+          }
+          existingSet.add(qText);
+          const diff = normalizeDifficulty(diffRaw);
+          if (!diff) {
+            errors.push(`Baris ${i + 2}: difficulty '${diffRaw}' tidak valid, dilewati`);
             continue;
           }
           batch.push({
-            clue: r.clue, answer: r.answer.replace(/\s+/g, "").toUpperCase(),
-            difficulty: diff as any, explanation: r.explanation || "",
+            clue: clueRaw, answer: ansRaw.replace(/\\s+/g, "").toUpperCase(),
+            difficulty: diff as any, explanation: expl,
             createdBy: user.id
           });
           if (batch.length >= BATCH_SIZE) {
@@ -358,8 +523,29 @@ export const bankSoalRoutes = new Elysia({ prefix: "/api/bank-soal" })
 
     } catch (err: any) {
       console.error("[bank-soal/import] Error:", err.message);
-      return new Response(JSON.stringify({ error: "Gagal memproses file CSV: " + err.message }), { status: 500 });
+      return new Response(JSON.stringify({ error: "Gagal memproses file Excel: " + err.message }), { status: 500 });
     }
+  })
+
+  // Debug endpoint: inspect CSV headers & first 3 rows (remove after debugging)
+  .post("/debug-csv", async ({ body }) => {
+    const formData = body as any;
+    const file = formData?.file;
+    if (!file || !(file instanceof Blob)) return { error: "no file" };
+    const text = await file.text();
+    const clean = text.startsWith('\uFEFF') ? text.slice(1) : text;
+    const firstLine = clean.split('\n')[0] || '';
+    const commaCount = (firstLine.match(/,/g) || []).length;
+    const semicolonCount = (firstLine.match(/;/g) || []).length;
+    const delim = semicolonCount > commaCount ? ';' : ',';
+    const lines = clean.replace(/\r\n/g,'\n').replace(/\r/g,'\n').split('\n').filter(l => l.trim());
+    return {
+      delimiter: delim,
+      totalLines: lines.length,
+      header: lines[0],
+      row1: lines[1] || '',
+      row2: lines[2] || ''
+    };
   })
 
   // ============================================================

--- a/src/views/components/BankSoalFtb.tsx
+++ b/src/views/components/BankSoalFtb.tsx
@@ -1,5 +1,5 @@
 export const BankSoalFtbUI = () => {
-  return `
+  const html = `
     <div class="p-6 md:p-10 space-y-8" x-data="bankSoalFtbData()">
       <!-- Header -->
       <div class="bg-white rounded-2xl shadow-sm border border-slate-100 p-6 flex flex-col md:flex-row md:items-center justify-between gap-4">
@@ -7,13 +7,22 @@ export const BankSoalFtbUI = () => {
           <h1 class="text-xl md:text-2xl font-bold text-[#1A237E] font-poppins">Bank Soal Fill The Blank</h1>
           <p class="text-sm text-slate-500 mt-1">Kelola bank soal rumpang secara global.</p>
         </div>
-        <div class="flex gap-2">
-          <button @click="openImportModal = true" class="px-4 py-2 bg-slate-100 text-slate-700 rounded-lg hover:bg-slate-200 transition-colors text-sm font-semibold flex items-center gap-2">
-            <i class="bi bi-download"></i> Import CSV
-          </button>
-          <button @click="openFormModal()" class="px-4 py-2 bg-[#FF5722] text-white rounded-lg hover:bg-[#E64A19] transition-colors text-sm font-bold flex items-center gap-2 shadow-md">
-            <i class="bi bi-plus-lg"></i> Tambah Soal
-          </button>
+        <div class="flex flex-col sm:flex-row gap-3 sm:items-center">
+          <div class="relative w-full sm:w-64">
+            <i class="bi bi-search absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"></i>
+            <input type="text" x-model="searchQuery" placeholder="Cari teks rumpang..." class="w-full pl-9 pr-4 py-2 border border-slate-200 rounded-lg text-sm focus:ring-2 focus:ring-[#1A237E] outline-none">
+          </div>
+          <div class="flex gap-2">
+            <button x-show="selectedIds.length > 0" @click="deleteSelected()" class="px-4 py-2 bg-red-100 text-red-600 rounded-lg hover:bg-red-200 transition-colors text-sm font-bold flex items-center gap-2 flex-1 justify-center sm:flex-none" x-transition>
+              <i class="bi bi-trash"></i> <span x-text="'Hapus (' + selectedIds.length + ')'"></span>
+            </button>
+            <button @click="openImportModal = true" class="px-4 py-2 bg-slate-100 text-slate-700 rounded-lg hover:bg-slate-200 transition-colors text-sm font-semibold flex items-center gap-2 flex-1 justify-center sm:flex-none">
+              <i class="bi bi-file-earmark-excel"></i> Import Excel
+            </button>
+            <button @click="openFormModal()" class="px-4 py-2 bg-[#FF5722] text-white rounded-lg hover:bg-[#E64A19] transition-colors text-sm font-bold flex items-center gap-2 shadow-md flex-1 justify-center sm:flex-none">
+              <i class="bi bi-plus-lg"></i> Tambah Soal
+            </button>
+          </div>
         </div>
       </div>
 
@@ -23,6 +32,11 @@ export const BankSoalFtbUI = () => {
           <table class="w-full text-left border-collapse">
             <thead>
               <tr class="bg-slate-50 border-b border-slate-100 text-slate-500 text-xs uppercase tracking-wider">
+                <th class="p-4 w-12 text-center">
+                  <input type="checkbox" class="rounded text-[#1A237E] focus:ring-[#1A237E] cursor-pointer"
+                         :checked="filteredSoalList().length > 0 && selectedIds.length === filteredSoalList().length"
+                         @change="$event.target.checked ? selectedIds = filteredSoalList().map(s => s.id) : selectedIds = []">
+                </th>
                 <th class="p-4 font-semibold w-2/5">Teks Utuh</th>
                 <th class="p-4 font-semibold">Kata Rumpang</th>
                 <th class="p-4 font-semibold text-center">Tingkat Kesulitan</th>
@@ -31,14 +45,17 @@ export const BankSoalFtbUI = () => {
             </thead>
             <tbody class="divide-y divide-slate-100">
               <template x-if="loading">
-                <tr><td colspan="4" class="p-8 text-center text-slate-500">Memuat data...</td></tr>
+                <tr><td colspan="5" class="p-8 text-center text-slate-500">Memuat data...</td></tr>
               </template>
               <template x-if="!loading && soalList.length === 0">
-                <tr><td colspan="4" class="p-8 text-center text-slate-500">Belum ada soal di Bank Soal FTB.</td></tr>
+                <tr><td colspan="5" class="p-8 text-center text-slate-500">Belum ada soal di Bank Soal FTB.</td></tr>
               </template>
-              <template x-for="soal in soalList" :key="soal.id">
-                <tr class="hover:bg-slate-50 transition-colors">
-                  <td class="p-4 text-sm text-slate-700 align-top max-w-sm truncate" x-text="soal.fullText"></td>
+              <template x-for="soal in filteredSoalList()" :key="soal.id">
+                <tr class="hover:bg-slate-50 transition-colors" :class="{'bg-blue-50/50': selectedIds.includes(soal.id)}">
+                  <td class="p-4 text-center align-top">
+                    <input type="checkbox" class="rounded text-[#1A237E] focus:ring-[#1A237E] cursor-pointer" :value="soal.id" x-model="selectedIds">
+                  </td>
+                  <td class="p-4 text-sm text-slate-700 align-top break-words" x-text="soal.fullText"></td>
                   <td class="p-4 text-xs text-slate-600 align-top">
                     <ul class="list-disc pl-4">
                       <template x-for="ans in soal.answers" :key="ans.word">
@@ -75,7 +92,7 @@ export const BankSoalFtbUI = () => {
           <div class="p-5 overflow-y-auto space-y-4">
             <div>
               <label class="block text-sm font-semibold text-slate-700 mb-1">Teks Utuh</label>
-              <textarea x-model="formData.fullText" class="w-full border border-slate-200 rounded-lg p-2.5 text-sm focus:ring-2 focus:ring-[#FFC107] outline-none" rows="4" placeholder="Masukkan teks. Gunakan tanda kurung buka dan tutup untuk menandai kata rumpang. Contoh: Ibukota Indonesia adalah [Jakarta]."></textarea>
+              <textarea x-model="formData.fullText" class="w-full border border-slate-200 rounded-lg p-2.5 text-sm focus:ring-2 focus:ring-[#FFC107] outline-none" rows="4" placeholder="Masukkan teks. Gunakan tanda kurung siku untuk menandai kata rumpang. Contoh: Ibukota Indonesia adalah [Jakarta]."></textarea>
             </div>
             <div>
               <label class="block text-sm font-semibold text-slate-700 mb-1">Tingkat Kesulitan</label>
@@ -85,14 +102,12 @@ export const BankSoalFtbUI = () => {
                 <option value="SULIT">Sulit</option>
               </select>
             </div>
-            
             <div class="border border-slate-200 rounded-lg p-4 bg-slate-50">
               <h4 class="text-sm font-bold text-slate-700 mb-2">Kata Rumpang</h4>
               <p class="text-xs text-slate-500 mb-3">Klik tombol untuk mengekstrak kata dalam kurung siku [...] dari teks utuh.</p>
               <button @click="extractAnswers()" class="px-3 py-1.5 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 text-xs font-semibold mb-3">
                 Ekstrak Kata
               </button>
-              
               <div class="space-y-2">
                 <template x-for="(ans, idx) in formData.answers" :key="idx">
                   <div class="flex gap-2 items-center">
@@ -101,7 +116,7 @@ export const BankSoalFtbUI = () => {
                   </div>
                 </template>
                 <template x-if="formData.answers.length === 0">
-                  <p class="text-xs text-slate-400 italic">Belum ada kata rumpang yang diekstrak.</p>
+                  <p class="text-xs text-slate-400 italic">Belum ada kata rumpang. Pastikan teks mengandung [...] lalu klik Ekstrak Kata.</p>
                 </template>
               </div>
             </div>
@@ -121,33 +136,37 @@ export const BankSoalFtbUI = () => {
             <button @click="openImportModal = false" class="text-slate-400 hover:text-red-500">&times;</button>
           </div>
           <div class="p-5 space-y-4">
-            <p class="text-sm text-slate-600">Gunakan file template CSV untuk mengimpor soal FTB secara massal. Format kolom wajib sesuai template.</p>
-            <button @click="downloadTemplate()" class="w-full py-2 border border-blue-200 text-blue-600 rounded-lg hover:bg-blue-50 text-sm font-semibold">
-              <i class="bi bi-download"></i> Unduh Template CSV
+            <p class="text-sm text-slate-600">Gunakan file template Excel (.xlsx) untuk mengimpor soal FTB secara massal. Format kolom wajib sesuai template.</p>
+            <button @click="downloadTemplate()" class="w-full py-2 border border-green-200 text-green-700 rounded-lg hover:bg-green-50 text-sm font-semibold flex items-center justify-center gap-2">
+              <i class="bi bi-file-earmark-excel"></i> Unduh Template Excel (.xlsx)
             </button>
             <div class="border-2 border-dashed border-slate-300 rounded-xl p-6 text-center hover:bg-slate-50 transition-colors">
-              <input type="file" id="fileImportFTB" accept=".csv" class="hidden" @change="handleFileChange">
+              <input type="file" id="fileImportFTB" accept=".xlsx,.xls" class="hidden" @change="handleFileChange">
               <label for="fileImportFTB" class="cursor-pointer flex flex-col items-center">
-                <i class="bi bi-file-earmark-text text-3xl mb-2 text-slate-400"></i>
-                <span class="text-sm font-semibold text-slate-700" x-text="selectedFileName || 'Klik untuk memilih file .csv'"></span>
-                <span class="text-xs text-slate-400 mt-1">Hanya file .csv yang diterima</span>
+                <i class="bi bi-file-earmark-excel text-3xl mb-2 text-green-500"></i>
+                <span class="text-sm font-semibold text-slate-700" x-text="selectedFileName || 'Klik untuk memilih file Excel (.xlsx)'"></span>
+                <span class="text-xs text-slate-400 mt-1">Hanya file .xlsx / .xls yang diterima</span>
               </label>
             </div>
           </div>
           <div class="p-5 border-t border-slate-100 flex justify-end gap-3 bg-slate-50">
             <button @click="openImportModal = false" class="px-4 py-2 text-slate-600 bg-slate-200 rounded-lg hover:bg-slate-300 font-semibold text-sm">Batal</button>
             <button @click="submitImport()" :disabled="!selectedFile || isImporting" class="px-4 py-2 text-white bg-[#FF5722] rounded-lg hover:bg-[#E64A19] disabled:opacity-50 font-semibold text-sm">
-              <span x-text="isImporting ? 'Mengimpor...' : 'Import'"></span>
+              <span x-text="isImporting ? 'Mengimpor...' : 'Mengimpor'"></span>
             </button>
           </div>
         </div>
       </div>
     </div>
+  `;
 
+  const script = `
     <script>
       function bankSoalFtbData() {
         return {
           soalList: [],
+          selectedIds: [],
+          searchQuery: '',
           loading: true,
           showForm: false,
           isEdit: false,
@@ -164,6 +183,11 @@ export const BankSoalFtbUI = () => {
           init() {
             this.fetchData();
           },
+          filteredSoalList() {
+            if (this.searchQuery.trim() === '') return this.soalList;
+            const q = this.searchQuery.toLowerCase();
+            return this.soalList.filter(function(s) { return (s.fullText || '').toLowerCase().indexOf(q) !== -1; });
+          },
           async fetchData() {
             this.loading = true;
             try {
@@ -179,21 +203,17 @@ export const BankSoalFtbUI = () => {
           },
           extractAnswers() {
             const matches = [...this.formData.fullText.matchAll(/\\[(.*?)\\]/g)];
-            // Pertahankan penjelasan yang sudah diisi jika kata sama
-            const newAnswers = matches.map(m => m[1]).filter(w => w.trim() !== "");
-            
+            const newAnswers = matches.map(function(m) { return m[1]; }).filter(function(w) { return w.trim() !== ""; });
             const currentAnsMap = {};
-            this.formData.answers.forEach(a => { currentAnsMap[a.word] = a.explanation; });
-
-            this.formData.answers = newAnswers.map(word => ({
-              word: word,
-              explanation: currentAnsMap[word] || ""
-            }));
+            this.formData.answers.forEach(function(a) { currentAnsMap[a.word] = a.explanation; });
+            this.formData.answers = newAnswers.map(function(word) {
+              return { word: word, explanation: currentAnsMap[word] || '' };
+            });
           },
-          openFormModal(soal = null) {
+          openFormModal(soal) {
             if (soal) {
               this.isEdit = true;
-              this.formData = { ...soal, answers: JSON.parse(JSON.stringify(soal.answers)) };
+              this.formData = { id: soal.id, fullText: soal.fullText, difficulty: soal.difficulty, answers: JSON.parse(JSON.stringify(soal.answers)) };
             } else {
               this.isEdit = false;
               this.formData = { id: null, fullText: '', answers: [], difficulty: 'MUDAH' };
@@ -207,9 +227,9 @@ export const BankSoalFtbUI = () => {
             }
             try {
               const method = this.isEdit ? 'PUT' : 'POST';
-              const url = this.isEdit ? \`/api/bank-soal/ftb/\${this.formData.id}\` : '/api/bank-soal/ftb';
+              const url = this.isEdit ? '/api/bank-soal/ftb/' + this.formData.id : '/api/bank-soal/ftb';
               const res = await fetch(url, {
-                method,
+                method: method,
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(this.formData)
               });
@@ -224,10 +244,27 @@ export const BankSoalFtbUI = () => {
               alert("Kesalahan sistem");
             }
           },
+          async deleteSelected() {
+            if (this.selectedIds.length === 0) return;
+            if (!confirm("Hapus " + this.selectedIds.length + " soal terpilih?")) return;
+            try {
+              const res = await fetch('/api/bank-soal/ftb/bulk-delete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ ids: this.selectedIds })
+              });
+              if (res.ok) {
+                this.selectedIds = [];
+                this.fetchData();
+              }
+            } catch (err) {
+              alert("Gagal menghapus soal terpilih");
+            }
+          },
           async deleteSoal(id) {
             if (!confirm("Hapus soal ini?")) return;
             try {
-              const res = await fetch(\`/api/bank-soal/ftb/\${id}\`, { method: 'DELETE' });
+              const res = await fetch('/api/bank-soal/ftb/' + id, { method: 'DELETE' });
               if (res.ok) this.fetchData();
             } catch (err) {
               alert("Gagal hapus");
@@ -252,11 +289,27 @@ export const BankSoalFtbUI = () => {
               });
               const json = await res.json();
               if (json.success) {
-                alert(\`Berhasil mengimpor \${json.imported} soal.\`);
+                let msg = "Berhasil mengimpor " + json.imported + " soal.";
+                if (json.warnings && json.warnings.length > 0) {
+                  const skipReasons = {};
+                  json.warnings.forEach(function(w) {
+                    if (w.indexOf('ganda') !== -1) skipReasons['duplikat'] = (skipReasons['duplikat'] || 0) + 1;
+                    else if (w.indexOf('word') !== -1 || w.indexOf('kata rumpang') !== -1) skipReasons['word kosong'] = (skipReasons['word kosong'] || 0) + 1;
+                    else if (w.indexOf('difficulty') !== -1) skipReasons['difficulty invalid'] = (skipReasons['difficulty invalid'] || 0) + 1;
+                    else if (w.indexOf('fullText') !== -1) skipReasons['fullText kosong'] = (skipReasons['fullText kosong'] || 0) + 1;
+                    else skipReasons['lainnya'] = (skipReasons['lainnya'] || 0) + 1;
+                  });
+                  let detail = ' | ' + json.warnings.length + ' dilewati: ';
+                  Object.keys(skipReasons).forEach(function(r) { detail += r + '=' + skipReasons[r] + ' '; });
+                  msg += detail;
+                  console.warn('[FTB Import Warnings]', json.warnings.slice(0, 30));
+                }
+                alert(msg);
                 this.openImportModal = false;
                 this.selectedFile = null;
                 this.selectedFileName = "";
-                document.getElementById('fileImportFTB').value = '';
+                const fi = document.getElementById('fileImportFTB');
+                if (fi) fi.value = '';
                 this.fetchData();
               } else {
                 alert(json.error || "Gagal import");
@@ -268,23 +321,17 @@ export const BankSoalFtbUI = () => {
             }
           },
           downloadTemplate() {
-            const rows = [
-              'fullText,difficulty,word1,explanation1,word2,explanation2,word3,explanation3',
-              'Ibukota Indonesia adalah [Jakarta] yang terletak di Pulau [Jawa].,MUDAH,Jakarta,Kota metropolitan terbesar di Indonesia,Jawa,Pulau terpadat di Indonesia,,',
-              'Proses fotosintesis menghasilkan [oksigen] dan [glukosa] dengan bantuan cahaya matahari.,SEDANG,oksigen,Gas yang dibutuhkan makhluk hidup untuk bernafas,glukosa,Sumber energi bagi tumbuhan,,',
-              'Teori relativitas dikemukakan oleh [Einstein] pada tahun [1905].,SULIT,Einstein,Fisikawan brilian asal Jerman,1905,Tahun diterbitkannya teori relativitas khusus,,'
-            ];
-            const csvContent = rows.join('\\n');
-            const blob = new Blob(['\uFEFF' + csvContent], { type: 'text/csv;charset=utf-8;' });
             const link = document.createElement('a');
-            link.href = URL.createObjectURL(blob);
-            link.download = 'Template_Bank_Soal_FTB.csv';
+            link.href = '/api/bank-soal/template/ftb';
+            link.download = 'Template_Bank_Soal_FTB.xlsx';
             document.body.appendChild(link);
             link.click();
             document.body.removeChild(link);
           }
         };
       }
-    </script>
+    <\/script>
   `;
+
+  return html + script;
 };

--- a/src/views/components/BankSoalQuiz.tsx
+++ b/src/views/components/BankSoalQuiz.tsx
@@ -7,13 +7,22 @@ export const BankSoalQuizUI = () => {
           <h1 class="text-xl md:text-2xl font-bold text-[#1A237E] font-poppins">Bank Soal Quiz</h1>
           <p class="text-sm text-slate-500 mt-1">Kelola bank soal Quiz secara global.</p>
         </div>
-        <div class="flex gap-2">
-          <button @click="openImportModal = true" class="px-4 py-2 bg-slate-100 text-slate-700 rounded-lg hover:bg-slate-200 transition-colors text-sm font-semibold flex items-center gap-2">
-            <i class="bi bi-download"></i> Import CSV
-          </button>
-          <button @click="openFormModal()" class="px-4 py-2 bg-[#FF5722] text-white rounded-lg hover:bg-[#E64A19] transition-colors text-sm font-bold flex items-center gap-2 shadow-md">
-            <i class="bi bi-plus-lg"></i> Tambah Soal
-          </button>
+        <div class="flex flex-col sm:flex-row gap-3 sm:items-center">
+          <div class="relative w-full sm:w-64">
+            <i class="bi bi-search absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"></i>
+            <input type="text" x-model="searchQuery" placeholder="Cari pertanyaan..." class="w-full pl-9 pr-4 py-2 border border-slate-200 rounded-lg text-sm focus:ring-2 focus:ring-[#1A237E] outline-none">
+          </div>
+          <div class="flex gap-2">
+            <button x-show="selectedIds.length > 0" @click="deleteSelected()" class="px-4 py-2 bg-red-100 text-red-600 rounded-lg hover:bg-red-200 transition-colors text-sm font-bold flex items-center gap-2 flex-1 justify-center sm:flex-none" x-transition>
+              <i class="bi bi-trash"></i> <span x-text="'Hapus (' + selectedIds.length + ')'"></span>
+            </button>
+            <button @click="openImportModal = true" class="px-4 py-2 bg-slate-100 text-slate-700 rounded-lg hover:bg-slate-200 transition-colors text-sm font-semibold flex items-center gap-2 flex-1 justify-center sm:flex-none">
+              <i class="bi bi-file-earmark-excel"></i> Import Excel
+            </button>
+            <button @click="openFormModal()" class="px-4 py-2 bg-[#FF5722] text-white rounded-lg hover:bg-[#E64A19] transition-colors text-sm font-bold flex items-center gap-2 shadow-md flex-1 justify-center sm:flex-none">
+              <i class="bi bi-plus-lg"></i> Tambah Soal
+            </button>
+          </div>
         </div>
       </div>
 
@@ -23,6 +32,11 @@ export const BankSoalQuizUI = () => {
           <table class="w-full text-left border-collapse">
             <thead>
               <tr class="bg-slate-50 border-b border-slate-100 text-slate-500 text-xs uppercase tracking-wider">
+                <th class="p-4 w-12 text-center">
+                  <input type="checkbox" class="rounded text-[#1A237E] focus:ring-[#1A237E] cursor-pointer" 
+                         :checked="filteredSoalList().length > 0 && selectedIds.length === filteredSoalList().length"
+                         @change="$event.target.checked ? selectedIds = filteredSoalList().map(s => s.id) : selectedIds = []">
+                </th>
                 <th class="p-4 font-semibold">Pertanyaan</th>
                 <th class="p-4 font-semibold">Opsi & Jawaban</th>
                 <th class="p-4 font-semibold text-center">Tingkat Kesulitan</th>
@@ -31,14 +45,17 @@ export const BankSoalQuizUI = () => {
             </thead>
             <tbody class="divide-y divide-slate-100">
               <template x-if="loading">
-                <tr><td colspan="4" class="p-8 text-center text-slate-500">Memuat data...</td></tr>
+                <tr><td colspan="5" class="p-8 text-center text-slate-500">Memuat data...</td></tr>
               </template>
               <template x-if="!loading && soalList.length === 0">
-                <tr><td colspan="4" class="p-8 text-center text-slate-500">Belum ada soal di Bank Soal Quiz.</td></tr>
+                <tr><td colspan="5" class="p-8 text-center text-slate-500">Belum ada soal di Bank Soal Quiz.</td></tr>
               </template>
-              <template x-for="soal in soalList" :key="soal.id">
-                <tr class="hover:bg-slate-50 transition-colors">
-                  <td class="p-4 text-sm text-slate-700 align-top max-w-xs truncate" x-text="soal.question"></td>
+              <template x-for="soal in filteredSoalList()" :key="soal.id">
+                <tr class="hover:bg-slate-50 transition-colors" :class="{'bg-blue-50/50': selectedIds.includes(soal.id)}">
+                  <td class="p-4 text-center align-top">
+                    <input type="checkbox" class="rounded text-[#1A237E] focus:ring-[#1A237E] cursor-pointer" :value="soal.id" x-model="selectedIds">
+                  </td>
+                  <td class="p-4 text-sm text-slate-700 align-top break-words" x-text="soal.question"></td>
                   <td class="p-4 text-xs text-slate-600 align-top">
                     <div>A: <span x-text="soal.optionA" :class="{'font-bold text-green-600': soal.correctAnswer === 'A'}"></span></div>
                     <div>B: <span x-text="soal.optionB" :class="{'font-bold text-green-600': soal.correctAnswer === 'B'}"></span></div>
@@ -133,16 +150,16 @@ export const BankSoalQuizUI = () => {
             <button @click="openImportModal = false" class="text-slate-400 hover:text-red-500">&times;</button>
           </div>
           <div class="p-5 space-y-4">
-            <p class="text-sm text-slate-600">Gunakan file template CSV untuk mengimpor soal secara massal. Format kolom wajib sesuai template.</p>
-            <button @click="downloadTemplate()" class="w-full py-2 border border-blue-200 text-blue-600 rounded-lg hover:bg-blue-50 text-sm font-semibold">
-              <i class="bi bi-download"></i> Unduh Template CSV
+            <p class="text-sm text-slate-600">Gunakan file template Excel (.xlsx) untuk mengimpor soal secara massal. Format kolom wajib sesuai template.</p>
+            <button @click="downloadTemplate()" class="w-full py-2 border border-green-200 text-green-700 rounded-lg hover:bg-green-50 text-sm font-semibold flex items-center justify-center gap-2">
+              <i class="bi bi-file-earmark-excel"></i> Unduh Template Excel (.xlsx)
             </button>
             <div class="border-2 border-dashed border-slate-300 rounded-xl p-6 text-center hover:bg-slate-50 transition-colors">
-              <input type="file" id="fileImport" accept=".csv" class="hidden" @change="handleFileChange">
+              <input type="file" id="fileImport" accept=".xlsx,.xls" class="hidden" @change="handleFileChange">
               <label for="fileImport" class="cursor-pointer flex flex-col items-center">
-                <i class="bi bi-file-earmark-text text-3xl mb-2 text-slate-400"></i>
-                <span class="text-sm font-semibold text-slate-700" x-text="selectedFileName || 'Klik untuk memilih file .csv'"></span>
-                <span class="text-xs text-slate-400 mt-1">Hanya file .csv yang diterima</span>
+                <i class="bi bi-file-earmark-excel text-3xl mb-2 text-green-500"></i>
+                <span class="text-sm font-semibold text-slate-700" x-text="selectedFileName || 'Klik untuk memilih file Excel (.xlsx)'"></span>
+                <span class="text-xs text-slate-400 mt-1">Hanya file .xlsx / .xls yang diterima</span>
               </label>
             </div>
           </div>
@@ -160,6 +177,8 @@ export const BankSoalQuizUI = () => {
       function bankSoalQuizData() {
         return {
           soalList: [],
+          selectedIds: [],
+          searchQuery: '',
           loading: true,
           showForm: false,
           isEdit: false,
@@ -180,6 +199,11 @@ export const BankSoalQuizUI = () => {
           },
           init() {
             this.fetchData();
+          },
+          filteredSoalList() {
+            if (this.searchQuery.trim() === '') return this.soalList;
+            const q = this.searchQuery.toLowerCase();
+            return this.soalList.filter(s => (s.question || '').toLowerCase().includes(q));
           },
           async fetchData() {
             this.loading = true;
@@ -207,7 +231,7 @@ export const BankSoalQuizUI = () => {
           async submitForm() {
             try {
               const method = this.isEdit ? 'PUT' : 'POST';
-              const url = this.isEdit ? \`/api/bank-soal/quiz/\${this.formData.id}\` : '/api/bank-soal/quiz';
+              const url = this.isEdit ? '/api/bank-soal/quiz/' + this.formData.id : '/api/bank-soal/quiz';
               const res = await fetch(url, {
                 method,
                 headers: { 'Content-Type': 'application/json' },
@@ -224,10 +248,27 @@ export const BankSoalQuizUI = () => {
               alert("Terjadi kesalahan sistem");
             }
           },
+          async deleteSelected() {
+            if (this.selectedIds.length === 0) return;
+            if (!confirm("Hapus " + this.selectedIds.length + " soal terpilih?")) return;
+            try {
+              const res = await fetch('/api/bank-soal/quiz/bulk-delete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ ids: this.selectedIds })
+              });
+              if (res.ok) {
+                this.selectedIds = [];
+                this.fetchData();
+              }
+            } catch (err) {
+              alert("Gagal menghapus soal terpilih");
+            }
+          },
           async deleteSoal(id) {
             if (!confirm("Hapus soal ini?")) return;
             try {
-              const res = await fetch(\`/api/bank-soal/quiz/\${id}\`, { method: 'DELETE' });
+              const res = await fetch('/api/bank-soal/quiz/' + id, { method: 'DELETE' });
               if (res.ok) this.fetchData();
             } catch (err) {
               alert("Gagal menghapus soal");
@@ -252,33 +293,34 @@ export const BankSoalQuizUI = () => {
               });
               const json = await res.json();
               if (json.success) {
-                alert(\`Berhasil mengimpor \${json.imported} soal.\`);
+                let msg = 'Berhasil mengimpor ' + json.imported + ' soal.';
+                if (json.warnings && json.warnings.length > 0) {
+                  const dup = json.warnings.filter(function(w) { return w.indexOf('ganda') !== -1; }).length;
+                  const skip = json.warnings.length - dup;
+                  if (dup > 0) msg += ' | ' + dup + ' duplikat dilewati.';
+                  if (skip > 0) msg += ' | ' + skip + ' baris lain dilewati.';
+                  console.warn('[Quiz Import]', json.warnings.slice(0, 20));
+                }
+                alert(msg);
                 this.openImportModal = false;
                 this.selectedFile = null;
-                this.selectedFileName = "";
-                document.getElementById('fileImport').value = '';
+                this.selectedFileName = '';
+                const fi = document.getElementById('fileImport');
+                if (fi) fi.value = '';
                 this.fetchData();
               } else {
-                alert(json.error || "Gagal import");
+                alert(json.error || 'Gagal import');
               }
             } catch (err) {
-              alert("Terjadi kesalahan saat import");
+              alert('Terjadi kesalahan saat import');
             } finally {
               this.isImporting = false;
             }
           },
           downloadTemplate() {
-            const rows = [
-              'question,optionA,optionB,optionC,optionD,correctAnswer,difficulty,explanation',
-              \`Siapa proklamator kemerdekaan Indonesia?,Soekarno dan Hatta,Suharto dan Habibie,Megawati dan Gus Dur,Jokowi dan Ma'ruf,A,MUDAH,Soekarno-Hatta memproklamasikan kemerdekaan pada 17 Agustus 1945\`,
-              \`Berapakah hasil dari 7 x 8?,54,56,58,60,B,SEDANG,7 dikali 8 sama dengan 56\`,
-              \`Apa nama hukum fisika yang menyatakan setiap aksi ada reaksi yang sama besar dan berlawanan arah?,Hukum Newton I,Hukum Newton II,Hukum Newton III,Hukum Archimedes,C,SULIT,Ini adalah Hukum Newton III tentang aksi-reaksi\`
-            ];
-            const csvContent = rows.join('\\n');
-            const blob = new Blob(['\uFEFF' + csvContent], { type: 'text/csv;charset=utf-8;' });
             const link = document.createElement('a');
-            link.href = URL.createObjectURL(blob);
-            link.download = 'Template_Bank_Soal_Quiz.csv';
+            link.href = '/api/bank-soal/template/quiz';
+            link.download = 'Template_Bank_Soal_Quiz.xlsx';
             document.body.appendChild(link);
             link.click();
             document.body.removeChild(link);

--- a/src/views/components/BankSoalTts.tsx
+++ b/src/views/components/BankSoalTts.tsx
@@ -7,13 +7,22 @@ export const BankSoalTtsUI = () => {
           <h1 class="text-xl md:text-2xl font-bold text-[#1A237E] font-poppins">Bank Soal TTS</h1>
           <p class="text-sm text-slate-500 mt-1">Kelola petunjuk dan jawaban Teka-Teki Silang.</p>
         </div>
-        <div class="flex gap-2">
-          <button @click="openImportModal = true" class="px-4 py-2 bg-slate-100 text-slate-700 rounded-lg hover:bg-slate-200 transition-colors text-sm font-semibold flex items-center gap-2">
-            <i class="bi bi-download"></i> Import CSV
-          </button>
-          <button @click="openFormModal()" class="px-4 py-2 bg-[#FF5722] text-white rounded-lg hover:bg-[#E64A19] transition-colors text-sm font-bold flex items-center gap-2 shadow-md">
-            <i class="bi bi-plus-lg"></i> Tambah Soal
-          </button>
+        <div class="flex flex-col sm:flex-row gap-3 sm:items-center">
+          <div class="relative w-full sm:w-64">
+            <i class="bi bi-search absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"></i>
+            <input type="text" x-model="searchQuery" placeholder="Cari clue..." class="w-full pl-9 pr-4 py-2 border border-slate-200 rounded-lg text-sm focus:ring-2 focus:ring-[#1A237E] outline-none">
+          </div>
+          <div class="flex gap-2">
+            <button x-show="selectedIds.length > 0" @click="deleteSelected()" class="px-4 py-2 bg-red-100 text-red-600 rounded-lg hover:bg-red-200 transition-colors text-sm font-bold flex items-center gap-2 flex-1 justify-center sm:flex-none" x-transition>
+              <i class="bi bi-trash"></i> <span x-text="'Hapus (' + selectedIds.length + ')'"></span>
+            </button>
+            <button @click="openImportModal = true" class="px-4 py-2 bg-slate-100 text-slate-700 rounded-lg hover:bg-slate-200 transition-colors text-sm font-semibold flex items-center gap-2 flex-1 justify-center sm:flex-none">
+              <i class="bi bi-file-earmark-excel"></i> Import Excel
+            </button>
+            <button @click="openFormModal()" class="px-4 py-2 bg-[#FF5722] text-white rounded-lg hover:bg-[#E64A19] transition-colors text-sm font-bold flex items-center gap-2 shadow-md flex-1 justify-center sm:flex-none">
+              <i class="bi bi-plus-lg"></i> Tambah Soal
+            </button>
+          </div>
         </div>
       </div>
 
@@ -23,6 +32,11 @@ export const BankSoalTtsUI = () => {
           <table class="w-full text-left border-collapse">
             <thead>
               <tr class="bg-slate-50 border-b border-slate-100 text-slate-500 text-xs uppercase tracking-wider">
+                <th class="p-4 w-12 text-center">
+                  <input type="checkbox" class="rounded text-[#1A237E] focus:ring-[#1A237E] cursor-pointer" 
+                         :checked="filteredSoalList().length > 0 && selectedIds.length === filteredSoalList().length"
+                         @change="$event.target.checked ? selectedIds = filteredSoalList().map(s => s.id) : selectedIds = []">
+                </th>
                 <th class="p-4 font-semibold w-1/2">Petunjuk (Clue)</th>
                 <th class="p-4 font-semibold">Jawaban</th>
                 <th class="p-4 font-semibold text-center">Tingkat Kesulitan</th>
@@ -31,14 +45,17 @@ export const BankSoalTtsUI = () => {
             </thead>
             <tbody class="divide-y divide-slate-100">
               <template x-if="loading">
-                <tr><td colspan="4" class="p-8 text-center text-slate-500">Memuat data...</td></tr>
+                <tr><td colspan="5" class="p-8 text-center text-slate-500">Memuat data...</td></tr>
               </template>
               <template x-if="!loading && soalList.length === 0">
-                <tr><td colspan="4" class="p-8 text-center text-slate-500">Belum ada soal di Bank Soal TTS.</td></tr>
+                <tr><td colspan="5" class="p-8 text-center text-slate-500">Belum ada soal di Bank Soal TTS.</td></tr>
               </template>
-              <template x-for="soal in soalList" :key="soal.id">
-                <tr class="hover:bg-slate-50 transition-colors">
-                  <td class="p-4 text-sm text-slate-700 align-top max-w-sm truncate">
+              <template x-for="soal in filteredSoalList()" :key="soal.id">
+                <tr class="hover:bg-slate-50 transition-colors" :class="{'bg-blue-50/50': selectedIds.includes(soal.id)}">
+                  <td class="p-4 text-center align-top">
+                    <input type="checkbox" class="rounded text-[#1A237E] focus:ring-[#1A237E] cursor-pointer" :value="soal.id" x-model="selectedIds">
+                  </td>
+                  <td class="p-4 text-sm text-slate-700 align-top break-words">
                     <div x-text="soal.clue"></div>
                     <div x-show="soal.explanation" class="text-xs text-slate-400 mt-1 italic" x-text="soal.explanation"></div>
                   </td>
@@ -109,16 +126,16 @@ export const BankSoalTtsUI = () => {
             <button @click="openImportModal = false" class="text-slate-400 hover:text-red-500">&times;</button>
           </div>
           <div class="p-5 space-y-4">
-            <p class="text-sm text-slate-600">Gunakan file template CSV untuk mengimpor petunjuk TTS secara massal. Format kolom wajib sesuai template.</p>
-            <button @click="downloadTemplate()" class="w-full py-2 border border-blue-200 text-blue-600 rounded-lg hover:bg-blue-50 text-sm font-semibold">
-              <i class="bi bi-download"></i> Unduh Template CSV
+            <p class="text-sm text-slate-600">Gunakan file template Excel (.xlsx) untuk mengimpor petunjuk TTS secara massal. Format kolom wajib sesuai template.</p>
+            <button @click="downloadTemplate()" class="w-full py-2 border border-green-200 text-green-700 rounded-lg hover:bg-green-50 text-sm font-semibold flex items-center justify-center gap-2">
+              <i class="bi bi-file-earmark-excel"></i> Unduh Template Excel (.xlsx)
             </button>
             <div class="border-2 border-dashed border-slate-300 rounded-xl p-6 text-center hover:bg-slate-50 transition-colors">
-              <input type="file" id="fileImportTTS" accept=".csv" class="hidden" @change="handleFileChange">
+              <input type="file" id="fileImportTTS" accept=".xlsx,.xls" class="hidden" @change="handleFileChange">
               <label for="fileImportTTS" class="cursor-pointer flex flex-col items-center">
-                <i class="bi bi-file-earmark-text text-3xl mb-2 text-slate-400"></i>
-                <span class="text-sm font-semibold text-slate-700" x-text="selectedFileName || 'Klik untuk memilih file .csv'"></span>
-                <span class="text-xs text-slate-400 mt-1">Hanya file .csv yang diterima</span>
+                <i class="bi bi-file-earmark-excel text-3xl mb-2 text-green-500"></i>
+                <span class="text-sm font-semibold text-slate-700" x-text="selectedFileName || 'Klik untuk memilih file Excel (.xlsx)'"></span>
+                <span class="text-xs text-slate-400 mt-1">Hanya file .xlsx / .xls yang diterima</span>
               </label>
             </div>
           </div>
@@ -136,6 +153,8 @@ export const BankSoalTtsUI = () => {
       function bankSoalTtsData() {
         return {
           soalList: [],
+          selectedIds: [],
+          searchQuery: '',
           loading: true,
           showForm: false,
           isEdit: false,
@@ -152,6 +171,11 @@ export const BankSoalTtsUI = () => {
           },
           init() {
             this.fetchData();
+          },
+          filteredSoalList() {
+            if (this.searchQuery.trim() === '') return this.soalList;
+            const q = this.searchQuery.toLowerCase();
+            return this.soalList.filter(s => (s.clue || '').toLowerCase().includes(q));
           },
           async fetchData() {
             this.loading = true;
@@ -183,7 +207,7 @@ export const BankSoalTtsUI = () => {
             }
             try {
               const method = this.isEdit ? 'PUT' : 'POST';
-              const url = this.isEdit ? \`/api/bank-soal/tts/\${this.formData.id}\` : '/api/bank-soal/tts';
+              const url = this.isEdit ? '/api/bank-soal/tts/' + this.formData.id : '/api/bank-soal/tts';
               const res = await fetch(url, {
                 method,
                 headers: { 'Content-Type': 'application/json' },
@@ -200,10 +224,27 @@ export const BankSoalTtsUI = () => {
               alert("Kesalahan sistem");
             }
           },
+          async deleteSelected() {
+            if (this.selectedIds.length === 0) return;
+            if (!confirm("Hapus " + this.selectedIds.length + " soal terpilih?")) return;
+            try {
+              const res = await fetch('/api/bank-soal/tts/bulk-delete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ ids: this.selectedIds })
+              });
+              if (res.ok) {
+                this.selectedIds = [];
+                this.fetchData();
+              }
+            } catch (err) {
+              alert("Gagal menghapus soal terpilih");
+            }
+          },
           async deleteSoal(id) {
             if (!confirm("Hapus soal ini?")) return;
             try {
-              const res = await fetch(\`/api/bank-soal/tts/\${id}\`, { method: 'DELETE' });
+              const res = await fetch('/api/bank-soal/tts/' + id, { method: 'DELETE' });
               if (res.ok) this.fetchData();
             } catch (err) {
               alert("Gagal hapus");
@@ -228,33 +269,34 @@ export const BankSoalTtsUI = () => {
               });
               const json = await res.json();
               if (json.success) {
-                alert(\`Berhasil mengimpor \${json.imported} soal.\`);
+                let msg = 'Berhasil mengimpor ' + json.imported + ' soal.';
+                if (json.warnings && json.warnings.length > 0) {
+                  const dup = json.warnings.filter(function(w) { return w.indexOf('ganda') !== -1; }).length;
+                  const skip = json.warnings.length - dup;
+                  if (dup > 0) msg += ' | ' + dup + ' duplikat dilewati.';
+                  if (skip > 0) msg += ' | ' + skip + ' baris lain dilewati.';
+                  console.warn('[TTS Import]', json.warnings.slice(0, 20));
+                }
+                alert(msg);
                 this.openImportModal = false;
                 this.selectedFile = null;
-                this.selectedFileName = "";
-                document.getElementById('fileImportTTS').value = '';
+                this.selectedFileName = '';
+                const fi = document.getElementById('fileImportTTS');
+                if (fi) fi.value = '';
                 this.fetchData();
               } else {
-                alert(json.error || "Gagal import");
+                alert(json.error || 'Gagal import');
               }
             } catch (err) {
-              alert("Kesalahan sistem saat import");
+              alert('Kesalahan sistem saat import');
             } finally {
               this.isImporting = false;
             }
           },
           downloadTemplate() {
-            const rows = [
-              'clue,answer,difficulty,explanation',
-              'Ibukota Indonesia,JAKARTA,MUDAH,Sekarang sedang dipindahkan ke IKN Nusantara',
-              'Planet terbesar di tata surya,JUPITER,SEDANG,Planet gas raksasa dengan badai besar di permukaannya',
-              'Ilmuwan yang menemukan hukum gravitasi,NEWTON,SULIT,Isaac Newton merumuskan hukum gravitasi universal'
-            ];
-            const csvContent = rows.join('\\n');
-            const blob = new Blob(['\uFEFF' + csvContent], { type: 'text/csv;charset=utf-8;' });
             const link = document.createElement('a');
-            link.href = URL.createObjectURL(blob);
-            link.download = 'Template_Bank_Soal_TTS.csv';
+            link.href = '/api/bank-soal/template/tts';
+            link.download = 'Template_Bank_Soal_TTS.xlsx';
             document.body.appendChild(link);
             link.click();
             document.body.removeChild(link);


### PR DESCRIPTION
- Changed Bank Soal (Quiz, FTB, TTS) import from text CSV to native Excel (.xlsx) using the 'xlsx' library.
- Enhanced Excel parsing to read all sheets and skip truly blank rows while keeping explicitly empty cells to prevent misalignment.
- Changed template download routes ('/api/bank-soal/template/:type') to dynamically generate and download properly formatted '.xlsx' template files.
- Updated front-end modals to request and accept '.xlsx' files and properly display validation messages regarding duplicates and skipped rows.
- Fixed a regex bug in FTB auto-heal logic ('\[\]' instead of '\\\[\\\]') to properly extract inline clues from the 'fullText'.